### PR TITLE
Add python 3.8 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
         'h5py',
         'pybedtools',
         'pydot',
-        'pysam',
+        'pysam<=1.15.4',
         'pyBigWig',
         'progress',
         'matplotlib',

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
         'h5py',
         'pybedtools',
         'pydot',
-        'pysam<=0.15.4',
+        'pysam<0.16,!=0.15.3',
         'pyBigWig',
         'progress',
         'matplotlib',

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
         'h5py',
         'pybedtools',
         'pydot',
-        'pysam<=1.15.4',
+        'pysam<=0.15.4',
         'pyBigWig',
         'progress',
         'matplotlib',

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
         'h5py',
         'pybedtools',
         'pydot',
-        'pysam<=0.15.3',
+        'pysam',
         'pyBigWig',
         'progress',
         'matplotlib',

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ deps =
     tensorflow==2.2.0
     pyBigWig
     pybedtools
-    pysam<=0.15.3
+    pysam<0.16,!=0.15.3
     urllib3
     matplotlib
     seaborn
@@ -71,7 +71,7 @@ deps =
     tensorflow==1.14.0
     pyBigWig
     pybedtools
-    pysam<=0.15.4
+    pysam<0.16,!=0.15.3
     urllib3
     matplotlib
     seaborn

--- a/tox.ini
+++ b/tox.ini
@@ -71,7 +71,7 @@ deps =
     tensorflow==1.14.0
     pyBigWig
     pybedtools
-    pysam<=0.15.3
+    pysam<=0.15.4
     urllib3
     matplotlib
     seaborn


### PR DESCRIPTION
**Update** pysam <=0.15.3 is incompatible with python 3.8 and above https://github.com/BIMSBbioinfo/janggu/pull/16#issuecomment-805835932

Is there a reason why pysam needs to be `<=0.15.3`? I wasn't able to build pysam in Ubuntu 20.10, but pysam was able to build when I bump pysam to the latest version (0.16.1)

```
$ lsb_release -a
No LSB modules are available.
Distributor ID:	Pop
Description:	Pop!_OS 20.10
Release:	20.10
Codename:	groovy
$ uname -r
5.8.0-7642-generic
```

Here is the error output for the 0.15.3 build. It is quite large so I truncate it here, but it's gcc related

```
    pysam/libcsamtools.c:318:11: error: too many arguments to function ‘PyCode_New’
      318 |           PyCode_New(a, 0, k, l, s, f, code, c, n, v, fv, cell, fn, name, fline, lnos)
          |           ^~~~~~~~~~
    pysam/libcsamtools.c:1668:15: note: in expansion of macro ‘__Pyx_PyCode_New’
     1668 |     py_code = __Pyx_PyCode_New(
          |               ^~~~~~~~~~~~~~~~
    In file included from /home/bruce/anaconda3/include/python3.8/compile.h:5,
                     from /home/bruce/anaconda3/include/python3.8/Python.h:138,
                     from pysam/libcsamtools.c:4:
    /home/bruce/anaconda3/include/python3.8/code.h:122:28: note: declared here
      122 | PyAPI_FUNC(PyCodeObject *) PyCode_New(
          |                            ^~~~~~~~~~
    error: command 'gcc' failed with exit status 1
    ----------------------------------------
```